### PR TITLE
fix: add token to checkout step in GitHub workflows

### DIFF
--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          token: ${{ secrets.DEPLOY_MODULE_GITHUB_TOKEN }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          token: ${{ secrets.DEPLOY_MODULE_GITHUB_TOKEN }}
       - name: Connect to AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION

This pull request updates GitHub Actions workflows to include a new secret for authentication when checking out submodules. The change ensures secure access to private repositories during workflow execution.

### Workflow updates for secure submodule access:

* [`.github/workflows/deploy_app.yaml`](diffhunk://#diff-1a2af3d38c87564e0784277bddf3ecaac64bfa2bd6c2326245349df9fba60f45R27): Added the `token` parameter with the `${{ secrets.DEPLOY_MODULE_GITHUB_TOKEN }}` value to the `actions/checkout` step.
* [`.github/workflows/terraform.yaml`](diffhunk://#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3eR21): Added the `token` parameter with the `${{ secrets.DEPLOY_MODULE_GITHUB_TOKEN }}` value to the `actions/checkout` step.