### PR TITLE
Feat enable request update checker by default

### DIFF
--- a/front/src/pages/AboutPage.tsx
+++ b/front/src/pages/AboutPage.tsx
@@ -7,6 +7,7 @@ import {
     Grid2,
     useTheme,
     useMediaQuery,
+    Link, // added Link import
 } from '@mui/material';
 import {
     Timeline,
@@ -16,7 +17,7 @@ import {
     TimelineContent,
     TimelineDot,
 } from '@mui/lab';
-import { Code as CodeIcon, Cloud as CloudIcon, Speed as SpeedIcon } from '@mui/icons-material';
+import { Code as CodeIcon, Cloud as CloudIcon, Speed as SpeedIcon, GitHub as GitHubIcon } from '@mui/icons-material';
 import LoginDialog from '../components/LoginDialog';
 import SignUpButton from '../components/SignUpButton';
 
@@ -160,6 +161,23 @@ export default function AboutPage() {
                 </Box>
 
                 <LoginDialog open={open} onClose={handleClose} />
+
+                <Box sx={{ mt: 4, display: 'flex', justifyContent: 'center' }}>
+                    <Link
+                        href="https://github.com/jesusnoseq/request-inbox"
+                        target="_blank"
+                        rel="noopener"
+                        underline="none"
+                        sx={{ display: 'inline-flex', alignItems: 'center' }}
+                    >
+                        <Paper elevation={2} sx={{ p: 1.5, display: 'flex', alignItems: 'center', bgcolor: 'background.paper', borderRadius: 2, transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 6 } }}>
+                            <GitHubIcon sx={{ mr: 1 }} />
+                            <Typography variant="button" color="textPrimary">
+                                View on GitHub
+                            </Typography>
+                        </Paper>
+                    </Link>
+                </Box>
             </Box>
         </Container>
     );


### PR DESCRIPTION
This pull request updates the `AboutPage` component to include a "View on GitHub" link, improving user accessibility to the project's GitHub repository. The changes involve adding necessary imports, as well as implementing the new link with styling and functionality.

### Updates to `AboutPage`:

* **Imported additional components**:
  - Added `Link` from `@mui/material` for creating the hyperlink.
  - Added `GitHubIcon` from `@mui/icons-material` for displaying the GitHub logo.

* **Added "View on GitHub" link**:
  - Implemented a styled `Link` component that redirects users to the project's GitHub repository. The link includes a `Paper` element with hover effects, a `GitHubIcon`, and a button-styled `Typography` element.