### PR TITLE
Feat/hide api keys

### DIFF
--- a/api/pkg/handler/apikey/apikey.go
+++ b/api/pkg/handler/apikey/apikey.go
@@ -80,7 +80,7 @@ func (h *APIKeyHandler) GetAPIKey(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, apiKey)
+	c.JSON(http.StatusOK, apiKey.WithMaskedKey())
 }
 
 func (h *APIKeyHandler) ListAPIKeysByUser(c *gin.Context) {
@@ -103,7 +103,12 @@ func (h *APIKeyHandler) ListAPIKeysByUser(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, model.NewItemList(apiKeys))
+	maskedAPIKeys := make([]model.APIKey, len(apiKeys))
+	for i, apiKey := range apiKeys {
+		maskedAPIKeys[i] = apiKey.WithMaskedKey()
+	}
+
+	c.JSON(http.StatusOK, model.NewItemList(maskedAPIKeys))
 }
 
 func (h *APIKeyHandler) DeleteAPIKey(c *gin.Context) {

--- a/api/pkg/handler/apikey/apikey_test.go
+++ b/api/pkg/handler/apikey/apikey_test.go
@@ -186,7 +186,7 @@ func TestGetAPIKey(t *testing.T) {
 		t.Fatalf("expected valid API key JSON response, got error: %v", err)
 	}
 	t_util.AssertSameID(t, apiKey.ID, returnedAPIKey.ID)
-	if string(t_util.MustJson(t, apiKey)) != string(t_util.MustJson(t, returnedAPIKey)) {
+	if string(t_util.MustJson(t, apiKey.WithMaskedKey())) != string(t_util.MustJson(t, returnedAPIKey)) {
 		t.Fatalf("expected the same API key in the JSON response \n%+v\n --- \n%+v", apiKey, returnedAPIKey)
 	}
 }
@@ -223,13 +223,13 @@ func TestListAPIKeysByUser(t *testing.T) {
 		t.Fatalf("expected valid Item list of API key JSON response, got error: %v", err)
 	}
 	t_util.AssertTrue(t, len(apiKeys.Results) >= 2, "Results len should be at least 2")
-	if !collection.SliceOfAnyContains(apiKeys.Results, apiKey1, ApiKeyEquals) {
+	if !collection.SliceOfAnyContains(apiKeys.Results, apiKey1.WithMaskedKey(), ApiKeyEquals) {
 		t.Errorf("API key list does not contains apiKey1 %+v", apiKey1)
 	}
-	if !collection.SliceOfAnyContains(apiKeys.Results, apiKey2, ApiKeyEquals) {
+	if !collection.SliceOfAnyContains(apiKeys.Results, apiKey2.WithMaskedKey(), ApiKeyEquals) {
 		t.Errorf("API key list does not contains apiKey2 %+v", apiKey2)
 	}
-	if collection.SliceOfAnyContains(apiKeys.Results, otherApiKey, ApiKeyEquals) {
+	if collection.SliceOfAnyContains(apiKeys.Results, otherApiKey.WithMaskedKey(), ApiKeyEquals) {
 		t.Errorf("API key list contains otherApiKey %+v", otherApiKey)
 	}
 }

--- a/api/pkg/model/apikey.go
+++ b/api/pkg/model/apikey.go
@@ -33,6 +33,13 @@ type APIKey struct {
 	Permissions  APIKeyPermissions
 }
 
+func (ak APIKey) WithMaskedKey() APIKey {
+	if len(ak.APIKey) > 6 {
+		ak.APIKey = ak.APIKey[:3] + "***" + ak.APIKey[len(ak.APIKey)-3:]
+	}
+	return ak
+}
+
 func generateAPIKey() (string, error) {
 	return randomString(API_KEY_SIZE)
 }

--- a/front/src/types/inbox.ts
+++ b/front/src/types/inbox.ts
@@ -3,11 +3,6 @@ export type InboxList = {
     results: Inbox[];
 }
 
-export type APIKeyList = {
-    count: number;
-    results: APIKey[];
-}
-
 export type Inbox = {
     ID: string;
     Name: string;
@@ -46,6 +41,11 @@ export type User = {
     Email: string;
     Organization: string;
     AvatarURL: string;
+}
+
+export type APIKeyList = {
+    count: number;
+    results: APIKey[];
 }
 
 export type APIKey = {


### PR DESCRIPTION
This pull request improves the security and user experience related to API key management. The main changes are: API keys are now masked by default in API responses, a new method for masking keys was added, and the frontend was updated to handle and display newly created keys securely, including a dedicated alert for new keys and improved visibility controls.

**Backend API key masking and handling:**

* API responses for retrieving a single API key (`GetAPIKey`) and listing API keys (`ListAPIKeysByUser`) now return masked versions of the API keys by using the new `WithMaskedKey` method. [[1]](diffhunk://#diff-25a275b667a09df49a669b1e3fead0bc5d1f64eafe4c4d83e2646a161b88a468L83-R83) [[2]](diffhunk://#diff-25a275b667a09df49a669b1e3fead0bc5d1f64eafe4c4d83e2646a161b88a468L106-R111)
* Added a `WithMaskedKey` method to the `APIKey` model in `apikey.go`, which masks the key except for the first and last three characters.

**Frontend API key management improvements:**

* Updated `APIKeyManager.tsx` to show a special alert with the full, unmasked value only when a new API key is created, allowing the user to copy or reveal/hide the key. Existing keys are always displayed masked as received from the backend, and per-row visibility toggling was removed for improved security. [[1]](diffhunk://#diff-1cb6fa15e8b87299a568d99d614e5360860494bbdcc98b50f10c2985f2978510L34-R39) [[2]](diffhunk://#diff-1cb6fa15e8b87299a568d99d614e5360860494bbdcc98b50f10c2985f2978510L76-R84) [[3]](diffhunk://#diff-1cb6fa15e8b87299a568d99d614e5360860494bbdcc98b50f10c2985f2978510L93-R101) [[4]](diffhunk://#diff-1cb6fa15e8b87299a568d99d614e5360860494bbdcc98b50f10c2985f2978510R117-R152) [[5]](diffhunk://#diff-1cb6fa15e8b87299a568d99d614e5360860494bbdcc98b50f10c2985f2978510L176-L185)
* Refactored import statements and minor UI code cleanup in `APIKeyManager.tsx`.

**Type definition cleanup:**

* Moved the `APIKeyList` type definition to a more appropriate place in `inbox.ts` for better organization. [[1]](diffhunk://#diff-d07d4e5eb5c4d4756e5e0dcc0dffed91f9768c32da9d3d975c4d7870693ef246L6-L10) [[2]](diffhunk://#diff-d07d4e5eb5c4d4756e5e0dcc0dffed91f9768c32da9d3d975c4d7870693ef246R46-R50)