### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: React CI
 
 on:

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: React CI
 
 on:
@@ -7,6 +5,9 @@ on:
     branches: [main]
     paths:
       - "front/**"
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/jesusnoseq/request-inbox/security/code-scanning/1](https://github.com/jesusnoseq/request-inbox/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since this workflow only checks out code, installs dependencies, lints, and builds, it does not require any write permissions. The minimal and recommended setting is `permissions: contents: read` at the top level of the workflow (just after the `name:` line), which will apply to all jobs unless overridden. This change should be made at the root of `.github/workflows/node.yaml`, above the `on:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
